### PR TITLE
Link app functions directly, without using eval

### DIFF
--- a/callery_pear.py
+++ b/callery_pear.py
@@ -9,15 +9,15 @@ st.set_page_config(page_title="Callery Pear", layout="wide")
 # A dictionary of apps in the format of {"App title": "App icon"}
 # More icons can be found here: https://icons.getbootstrap.com
 
-apps = {
-    "callery_home": {"title": "Home", "icon": "house"},
-    "callery_photos": {"title": "Photos", "icon": "images"},
-    "callery_naip": {"title": "NAIP Imagery (1-m)", "icon": "globe"},
-    "callery_planet": {"title": "Planet Imagery (5-m)", "icon": "camera"},
-}
+apps = [
+    {"func": callery_home.app, "title": "Home", "icon": "house"},
+    {"func": callery_photos.app, "title": "Photos", "icon": "images"},
+    {"func": callery_naip.app, "title": "NAIP Imagery (1-m)", "icon": "globe"},
+    {"func": callery_planet.app, "title": "Planet Imagery (5-m)", "icon": "camera"},
+]
 
-titles = [app["title"] for app in apps.values()]
-icons = [app["icon"] for app in apps.values()]
+titles = [app["title"] for app in apps]
+icons = [app["icon"] for app in apps]
 
 params = st.experimental_get_query_params()
 
@@ -45,6 +45,6 @@ with st.sidebar:
     )
 
 for app in apps:
-    if apps[app]["title"] == selected:
-        eval(f"{app}.app()")
+    if app["title"] == selected:
+        app["func"]()
         break

--- a/interact.py
+++ b/interact.py
@@ -9,12 +9,12 @@ st.set_page_config(page_title="Streamlit Folium", layout="wide")
 # A dictionary of apps in the format of {"App title": "App icon"}
 # More icons can be found here: https://icons.getbootstrap.com
 
-apps = {
-    "get_bounds": {"title": "Home", "icon": "house"},
-}
+apps = [
+    {"func":get_bounds.app, "title": "Home", "icon": "house"},
+]
 
-titles = [app["title"] for app in apps.values()]
-icons = [app["icon"] for app in apps.values()]
+titles = [app["title"] for app in apps]
+icons = [app["icon"] for app in apps]
 
 params = st.experimental_get_query_params()
 
@@ -42,6 +42,7 @@ with st.sidebar:
     )
 
 for app in apps:
-    if apps[app]["title"] == selected:
-        eval(f"{app}.app()")
+    if app["title"] == selected:
+        app["func"]()
         break
+    

--- a/ntl.py
+++ b/ntl.py
@@ -9,12 +9,12 @@ st.set_page_config(page_title="Nighttime Light Data Analysis", layout="wide")
 # A dictionary of apps in the format of {"App title": "App icon"}
 # More icons can be found here: https://icons.getbootstrap.com
 
-apps = {
-    "viirs": {"title": "Home", "icon": "house"},
-}
+apps = [
+    {"func":viirs.app, "title": "Home", "icon": "house"},
+]
 
-titles = [app["title"] for app in apps.values()]
-icons = [app["icon"] for app in apps.values()]
+titles = [app["title"] for app in apps]
+icons = [app["icon"] for app in apps]
 
 params = st.experimental_get_query_params()
 
@@ -42,6 +42,6 @@ with st.sidebar:
     )
 
 for app in apps:
-    if apps[app]["title"] == selected:
-        eval(f"{app}.app()")
+    if app["title"] == selected:
+        app["func"]()
         break

--- a/raster.py
+++ b/raster.py
@@ -9,12 +9,12 @@ st.set_page_config(page_title="Search Geographic Names", layout="wide")
 # A dictionary of apps in the format of {"App title": "App icon"}
 # More icons can be found here: https://icons.getbootstrap.com
 
-apps = {
-    "cog": {"title": "Home", "icon": "house"},
-}
+apps = [
+    {"func":cog.app, "title": "Home", "icon": "house"},
+]
 
-titles = [app["title"] for app in apps.values()]
-icons = [app["icon"] for app in apps.values()]
+titles = [app["title"] for app in apps]
+icons = [app["icon"] for app in apps]
 
 params = st.experimental_get_query_params()
 
@@ -40,6 +40,6 @@ with st.sidebar:
     )
 
 for app in apps:
-    if apps[app]["title"] == selected:
-        eval(f"{app}.app()")
+    if app["title"] == selected:
+        app["func"]()
         break

--- a/search_names.py
+++ b/search_names.py
@@ -9,12 +9,12 @@ st.set_page_config(page_title="Search Geographic Names", layout="wide")
 # A dictionary of apps in the format of {"App title": "App icon"}
 # More icons can be found here: https://icons.getbootstrap.com
 
-apps = {
-    "osm_names": {"title": "Home", "icon": "house"},
-}
+apps = [
+    {"func":osm_names.app, "title": "Home", "icon": "house"},
+]
 
-titles = [app["title"] for app in apps.values()]
-icons = [app["icon"] for app in apps.values()]
+titles = [app["title"] for app in apps]
+icons = [app["icon"] for app in apps]
 
 params = st.experimental_get_query_params()
 
@@ -42,6 +42,6 @@ with st.sidebar:
     )
 
 for app in apps:
-    if apps[app]["title"] == selected:
-        eval(f"{app}.app()")
+    if app["title"] == selected:
+        app["func"]()
         break

--- a/split_map.py
+++ b/split_map.py
@@ -9,13 +9,13 @@ st.set_page_config(page_title="Split-panel Map", layout="wide")
 # A dictionary of apps in the format of {"App title": "App icon"}
 # More icons can be found here: https://icons.getbootstrap.com
 
-apps = {
-    "split": {"title": "Home", "icon": "house"},
-    "scotland": {"title": "Scotland", "icon": "globe"},
-}
+apps = [
+    {"func":split.app, "title": "Home", "icon": "house"},
+    {"func":scotland.app, "title": "Scotland", "icon": "globe"},
+]
 
-titles = [app["title"] for app in apps.values()]
-icons = [app["icon"] for app in apps.values()]
+titles = [app["title"] for app in apps]
+icons = [app["icon"] for app in apps]
 
 params = st.experimental_get_query_params()
 
@@ -43,6 +43,6 @@ with st.sidebar:
     )
 
 for app in apps:
-    if apps[app]["title"] == selected:
-        eval(f"{app}.app()")
+    if app["title"] == selected:
+        app["func"]()
         break

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,14 +7,14 @@ st.set_page_config(page_title="Streamlit Geospatial", layout="wide")
 # A dictionary of apps in the format of {"App title": "App icon"}
 # More icons can be found here: https://icons.getbootstrap.com
 
-apps = {
-    "home": {"title": "Home", "icon": "house"},
-    "heatmap": {"title": "Heatmap", "icon": "map"},
-    "upload": {"title": "Upload", "icon": "cloud-upload"},
-}
+apps = [
+    {"func":home.app, "title": "Home", "icon": "house"},
+    {"func":heatmap.app, "title": "Heatmap", "icon": "map"},
+    {"func":upload.app, "title": "Upload", "icon": "cloud-upload"},
+]
 
-titles = [app["title"] for app in apps.values()]
-icons = [app["icon"] for app in apps.values()]
+titles = [app["title"] for app in apps]
+icons = [app["icon"] for app in apps]
 
 params = st.experimental_get_query_params()
 
@@ -45,6 +45,6 @@ with st.sidebar:
     )
 
 for app in apps:
-    if apps[app]["title"] == selected:
-        eval(f"{app}.app()")
+    if app["title"] == selected:
+        app["func"]()
         break

--- a/xyz.py
+++ b/xyz.py
@@ -9,12 +9,12 @@ st.set_page_config(page_title="Split-panel Map", layout="wide")
 # A dictionary of apps in the format of {"App title": "App icon"}
 # More icons can be found here: https://icons.getbootstrap.com
 
-apps = {
-    "scotland": {"title": "Home", "icon": "house"},
-}
+apps = [
+    {"func":scotland.app, "title": "Home", "icon": "house"},
+]
 
-titles = [app["title"] for app in apps.values()]
-icons = [app["icon"] for app in apps.values()]
+titles = [app["title"] for app in apps]
+icons = [app["icon"] for app in apps]
 
 params = st.experimental_get_query_params()
 
@@ -46,6 +46,6 @@ with st.sidebar:
     st.sidebar.info(markdown)
 
 for app in apps:
-    if apps[app]["title"] == selected:
-        eval(f"{app}.app()")
+    if app["title"] == selected:
+        app["func"]()
         break


### PR DESCRIPTION
With these changes, the pylint does not gives warnings about seemingly unused imports and usage of `eval`